### PR TITLE
Wordpress plugindirecotry feedback

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1,13 +1,17 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+  exit; // Exit if accessed directly
+}
+
 /* Add Swiss Phone Format to GravityForms Phone Field */
 function spsgf_ch_phone_format( $phone_formats ) {
-    $phone_formats['uk'] = array(
-        'label'       => 'Switzerland',
-        'mask'        => '+41 99 999 99 99',
-        'regex'       => '/^(?:\+41|0041|0)?\s?(?:\d{2}\s?\d{3}\s?\d{2}\s?\d{2})$/',
-        'instruction' => '+41 79 000 00 00',
-    );
- 
-    return $phone_formats;
+  $phone_formats['uk'] = array(
+    'label'       => 'Switzerland',
+    'mask'        => '+41 99 999 99 99',
+    'regex'       => '/^(?:\+41|0041|0)?\s?(?:\d{2}\s?\d{3}\s?\d{2}\s?\d{2})$/',
+    'instruction' => '+41 79 000 00 00',
+  );
+
+  return $phone_formats;
 }
 add_filter( 'gform_phone_formats', 'spsgf_ch_phone_format' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://github.com/sponsors/srueegger
 Tags: gravityforms, switzerland, phone
 Requires at least: 6.6
 Tested up to: 6.6
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 Requires PHP: 8.1
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/swissphone-select-for-gravityforms.php
+++ b/swissphone-select-for-gravityforms.php
@@ -31,6 +31,10 @@
  * @package PreferredLanguages
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+  exit; // Exit if accessed directly
+}
+
 /* Check if GravityForms is active */
 function spsgf_activation_check() {
   if ( !is_plugin_active( 'gravityforms/gravityforms.php' ) ) {

--- a/swissphone-select-for-gravityforms.php
+++ b/swissphone-select-for-gravityforms.php
@@ -3,7 +3,7 @@
  * Plugin Name: SwissPhone Select for GravityForms
  * Plugin URI:  https://github.com/srueegger/SwissPhone-Select-for-GravityForms
  * Description: SwissPhone Select for GravityForms is a lightweight WordPress plugin that adds Switzerland (+41) as a selectable option for phone number fields in your GravityForms. Make it easier for Swiss users to fill out forms by providing a convenient country code option and enhancing the overall user experience.
- * Version:     1.0.1
+ * Version:     1.0.2
  * Author:      Samuel Rüegger
  * Author URI:  https://rueegger.me
  * License:     GPL-2.0


### PR DESCRIPTION
## Allowing Direct File Access to plugin files

Direct file access is when someone directly queries your file. This can be done by simply entering the complete path to the file in the URL bar of the browser but can also be done by doing a POST request directly to the file. For files that only contain a PHP class the risk of something funky happening when directly accessed is pretty small. For files that contain procedural code, functions and function calls, the chance of security risks is a lot bigger.

You can avoid this by putting this code at the top of all PHP files that could potentially execute code if accessed directly :
     if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly 

Example(s) from your plugin:

swissphone-select-for-gravityforms.php:42 